### PR TITLE
Code refactoring, including changing filters to jinja tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,16 +7,26 @@ python:
   - "2.7"
 
 env:
-  - DJANGO=django==1.8.6
-  - DJANGO=django==1.7.10
+  - DJANGO=django==1.11.3 DJANGO_JINJA=django-jinja==2.3.0
+  - DJANGO=django==1.10.7 DJANGO_JINJA=django-jinja==2.2.1
+  - DJANGO=django==1.9.13 DJANGO_JINJA=django-jinja==2.2.1
+  - DJANGO=django==1.8.18 DJANGO_JINJA=django-jinja==2.1.2
+  - DJANGO=django==1.8.18 DJANGO_JINJA=django-jinja==1.4.2
+  - DJANGO=django==1.7.11 DJANGO_JINJA=django-jinja==1.4.2
 
 matrix:
   exclude:
     - python: "3.5"
-      env: DJANGO=django==1.7.10
+      env: DJANGO=django==1.7.11 DJANGO_JINJA=django-jinja==1.4.2
+    - python: "3.3"
+      env: DJANGO=django==1.11.3 DJANGO_JINJA=django-jinja==2.3.0
+    - python: "3.3"
+      env: DJANGO=django==1.10.7 DJANGO_JINJA=django-jinja==2.2.1
+    - python: "3.3"
+      env: DJANGO=django==1.9.13 DJANGO_JINJA=django-jinja==2.2.1
 
 install:
-  - pip install $DJANGO django-jinja==1.4.1 flake8
+  - pip install $DJANGO $DJANGO_JINJA flake8
 
 script:
   - flake8 --max-line-length 120 bootstrapform_jinja/

--- a/bootstrapform_jinja/__init__.py
+++ b/bootstrapform_jinja/__init__.py
@@ -1,3 +1,5 @@
 from .meta import VERSION
 
 __version__ = str(VERSION)
+
+default_app_config = 'bootstrapform_jinja.apps.BootstrapformJinjaConfig'

--- a/bootstrapform_jinja/apps.py
+++ b/bootstrapform_jinja/apps.py
@@ -1,0 +1,10 @@
+from django.apps import AppConfig
+
+
+class BootstrapformJinjaConfig(AppConfig):
+    name = 'bootstrapform_jinja'
+    verbose_name = "Bootstrapform for Jinja"
+
+    def ready(self):
+        # Make sure tags are registered
+        from .templatetags import bootstrap  # NOQA

--- a/bootstrapform_jinja/templates/bootstrapform/field.jinja
+++ b/bootstrapform_jinja/templates/bootstrapform/field.jinja
@@ -1,3 +1,3 @@
-{% import 'bootstrapform/field_macros.jinja' as field_macros with context %}
+{% import 'bootstrapform/field_macros.jinja' as field_macros %}
 
-{{ field_macros.render(field) }}
+{{ field_macros.render(form, field, classes) }}

--- a/bootstrapform_jinja/templates/bootstrapform/field_macros.jinja
+++ b/bootstrapform_jinja/templates/bootstrapform/field_macros.jinja
@@ -61,7 +61,7 @@
   </div>
 {%- endmacro %}
 
-{% macro render(field) -%}
+{% macro render(form, field, classes) -%}
 <div class="form-group{% if field.errors %} has-error{% endif %}">
   {% if field|is_checkbox %}
     {{ render_field_checkbox(form, field, classes) }}

--- a/bootstrapform_jinja/templates/bootstrapform/field_macros.jinja
+++ b/bootstrapform_jinja/templates/bootstrapform/field_macros.jinja
@@ -20,7 +20,7 @@
 
 {% macro render_field_radio(form, field, classes) -%}
   {% if field.auto_id %}
-    <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class or 'required' }}{% endif %}">{{ field.label }}</label>
+    <label class="control-label {{ classes.label }}{% if field.field.required %} {{ form.required_css_class or 'required' }}{% endif %}">{{ field.label }}</label>
   {% endif %}
   <div class="{{ classes.value }}">
     {% for choice in field %}
@@ -48,7 +48,7 @@
     <label class="control-label {{ classes.label }} {% if field.field.required %}{{ form.required_css_class or 'required' }}{% endif %}" for="{{ field.auto_id }}">{{ field.label }}</label>
   {% endif %}
 
-  <div class="{{ classes.value }} {% if field|is_multiple_checkbox %}multiple-checkbox{% endif %}">
+  <div class="{{ classes.value }}{% if field is multiple_checkbox_field %} multiple-checkbox{% endif %}">
     {{ field|safe }}
     {% for error in field.errors %}
       <span class="help-block {{ form.error_css_class or 'error-msg' }}">{{ error }}</span>
@@ -63,9 +63,9 @@
 
 {% macro render(form, field, classes) -%}
 <div class="form-group{% if field.errors %} has-error{% endif %}">
-  {% if field|is_checkbox %}
+  {% if field is checkbox_field %}
     {{ render_field_checkbox(form, field, classes) }}
-  {% elif field|is_radio %}
+  {% elif field is radio_field %}
     {{ render_field_radio(form, field, classes) }}
   {% else %}
     {{ render_field_standard(form, field, classes) }}

--- a/bootstrapform_jinja/templates/bootstrapform/form.jinja
+++ b/bootstrapform_jinja/templates/bootstrapform/form.jinja
@@ -1,5 +1,6 @@
-{% import 'bootstrapform/field_macros.jinja' as field_macros with context %}
-{% if form.non_field_errors() %}
+{% import 'bootstrapform/field_macros.jinja' as field_macros %}
+
+{%- if form.non_field_errors() %}
   <div class="alert alert-danger">
     <a class="close" data-dismiss="alert">&times;</a>
     {% for non_field_error in form.non_field_errors() %}
@@ -13,5 +14,5 @@
 {% endfor -%}
 
 {%- for field in form.visible_fields() %}
-  {{ field_macros.render(field) }}
+  {{ field_macros.render(form, field, classes) }}
 {% endfor %}

--- a/bootstrapform_jinja/templatetags/bootstrap.py
+++ b/bootstrapform_jinja/templatetags/bootstrap.py
@@ -1,9 +1,42 @@
-from django import forms
+from django.forms import CheckboxInput, CheckboxSelectMultiple, FileInput, RadioSelect
 from django.template.loader import get_template
-from django_jinja import library
 from django.utils.safestring import mark_safe
+from django_jinja import library
 
 from bootstrapform_jinja import config
+
+
+@library.test
+def checkbox_field(field):
+    """
+    Jinja test to check if a field is a checkbox
+    """
+    return isinstance(field.field.widget, CheckboxInput)
+
+
+@library.test
+def multiple_checkbox_field(field):
+    """
+    Jinja test to check if a field is a multiple value checkbox
+    """
+    return isinstance(field.field.widget, CheckboxSelectMultiple)
+
+
+@library.test
+def radio_field(field):
+    """
+    Jinja test to check if a field is a radio select
+    """
+    return isinstance(field.field.widget, RadioSelect)
+
+
+def add_input_classes(field):
+    """
+    Add form-control to class attribute of the widget of the given field.
+    """
+    if not isinstance(field.field.widget, (CheckboxInput, CheckboxSelectMultiple, RadioSelect, FileInput)):
+        attrs = field.field.widget.attrs
+        attrs['class'] = attrs.get('class', '') + ' form-control'
 
 
 @library.filter
@@ -51,13 +84,6 @@ def bootstrap_horizontal(element, label_cols={}):
     return render(element, markup_classes)
 
 
-def add_input_classes(field):
-    if not is_checkbox(field) and not is_multiple_checkbox(field) and not is_radio(field) and not is_file(field):
-        field_classes = field.field.widget.attrs.get('class', '')
-        field_classes += ' form-control'
-        field.field.widget.attrs['class'] = field_classes
-
-
 def render(element, markup_classes):
     element_type = element.__class__.__name__.lower()
 
@@ -88,23 +114,3 @@ def render(element, markup_classes):
 def bootstrap_classes(field):
     add_input_classes(field)
     return mark_safe(field)
-
-
-@library.filter
-def is_checkbox(field):
-    return isinstance(field.field.widget, forms.CheckboxInput)
-
-
-@library.filter
-def is_multiple_checkbox(field):
-    return isinstance(field.field.widget, forms.CheckboxSelectMultiple)
-
-
-@library.filter
-def is_radio(field):
-    return isinstance(field.field.widget, forms.RadioSelect)
-
-
-@library.filter
-def is_file(field):
-    return isinstance(field.field.widget, forms.FileInput)

--- a/testing/fixtures/basic.html
+++ b/testing/fixtures/basic.html
@@ -1,14 +1,14 @@
   <div class="form-group">
         <label class="control-label  required" for="id_char_field">Char field</label>
 
-  <div class=" ">
+  <div class="">
     <input class=" form-control" id="id_char_field" name="char_field" type="text" />
   </div>
 </div>
   <div class="form-group">
         <label class="control-label  required" for="id_choice_field">Choice field</label>
 
-  <div class=" ">
+  <div class="">
     <select class=" form-control" id="id_choice_field" name="choice_field">
 <option value="0">Zero</option>
 <option value="1">One</option>
@@ -43,7 +43,7 @@
   <div class="form-group">
         <label class="control-label  required" for="id_multiple_choice">Multiple choice</label>
 
-  <div class=" ">
+  <div class="">
     <select multiple="multiple" class=" form-control" id="id_multiple_choice" name="multiple_choice">
 <option value="0">Zero</option>
 <option value="1">One</option>
@@ -63,21 +63,21 @@
   <div class="form-group">
         <label class="control-label  required" for="id_file_fied">File fied</label>
 
-  <div class=" ">
+  <div class="">
     <input id="id_file_fied" name="file_fied" type="file" />
   </div>
 </div>
   <div class="form-group">
         <label class="control-label  required" for="id_password_field">Password field</label>
 
-  <div class=" ">
+  <div class="">
     <input class=" form-control" id="id_password_field" name="password_field" type="password" />
   </div>
 </div>
   <div class="form-group">
         <label class="control-label  required" for="id_textarea">Textarea</label>
 
-  <div class=" ">
+  <div class="">
     <textarea class=" form-control" cols="40" id="id_textarea" name="textarea" rows="10">
 </textarea>
   </div>

--- a/testing/fixtures/horizontal.html
+++ b/testing/fixtures/horizontal.html
@@ -1,14 +1,14 @@
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_char_field">Char field</label>
 
-  <div class=" col-sm-10 col-lg-10 ">
+  <div class=" col-sm-10 col-lg-10">
     <input class=" form-control" id="id_char_field" name="char_field" type="text" />
   </div>
 </div>
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_choice_field">Choice field</label>
 
-  <div class=" col-sm-10 col-lg-10 ">
+  <div class=" col-sm-10 col-lg-10">
     <select class=" form-control" id="id_choice_field" name="choice_field">
 <option value="0">Zero</option>
 <option value="1">One</option>
@@ -43,7 +43,7 @@
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_multiple_choice">Multiple choice</label>
 
-  <div class=" col-sm-10 col-lg-10 ">
+  <div class=" col-sm-10 col-lg-10">
     <select multiple="multiple" class=" form-control" id="id_multiple_choice" name="multiple_choice">
 <option value="0">Zero</option>
 <option value="1">One</option>
@@ -63,21 +63,21 @@
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_file_fied">File fied</label>
 
-  <div class=" col-sm-10 col-lg-10 ">
+  <div class=" col-sm-10 col-lg-10">
     <input id="id_file_fied" name="file_fied" type="file" />
   </div>
 </div>
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_password_field">Password field</label>
 
-  <div class=" col-sm-10 col-lg-10 ">
+  <div class=" col-sm-10 col-lg-10">
     <input class=" form-control" id="id_password_field" name="password_field" type="password" />
   </div>
 </div>
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_textarea">Textarea</label>
 
-  <div class=" col-sm-10 col-lg-10 ">
+  <div class=" col-sm-10 col-lg-10">
     <textarea class=" form-control" cols="40" id="id_textarea" name="textarea" rows="10">
 </textarea>
   </div>

--- a/testing/fixtures/horizontal.html
+++ b/testing/fixtures/horizontal.html
@@ -1,14 +1,14 @@
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_char_field">Char field</label>
 
-  <div class=" col-sm-10 col-lg-10">
+  <div class="col-sm-10 col-lg-10">
     <input class=" form-control" id="id_char_field" name="char_field" type="text" />
   </div>
 </div>
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_choice_field">Choice field</label>
 
-  <div class=" col-sm-10 col-lg-10">
+  <div class="col-sm-10 col-lg-10">
     <select class=" form-control" id="id_choice_field" name="choice_field">
 <option value="0">Zero</option>
 <option value="1">One</option>
@@ -18,7 +18,7 @@
 </div>
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required">Radio choice</label>
-  <div class=" col-sm-10 col-lg-10">
+  <div class="col-sm-10 col-lg-10">
       <div class="radio">
         <label>
           <input id="id_radio_choice_0" name="radio_choice" type="radio" value="0" />
@@ -43,7 +43,7 @@
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_multiple_choice">Multiple choice</label>
 
-  <div class=" col-sm-10 col-lg-10">
+  <div class="col-sm-10 col-lg-10">
     <select multiple="multiple" class=" form-control" id="id_multiple_choice" name="multiple_choice">
 <option value="0">Zero</option>
 <option value="1">One</option>
@@ -54,7 +54,7 @@
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_multiple_checkbox">Multiple checkbox</label>
 
-  <div class=" col-sm-10 col-lg-10 multiple-checkbox">
+  <div class="col-sm-10 col-lg-10 multiple-checkbox">
     <ul id="id_multiple_checkbox"><li><label for="id_multiple_checkbox_0"><input id="id_multiple_checkbox_0" name="multiple_checkbox" type="checkbox" value="0" /> Zero</label></li>
 <li><label for="id_multiple_checkbox_1"><input id="id_multiple_checkbox_1" name="multiple_checkbox" type="checkbox" value="1" /> One</label></li>
 <li><label for="id_multiple_checkbox_2"><input id="id_multiple_checkbox_2" name="multiple_checkbox" type="checkbox" value="2" /> Two</label></li></ul>
@@ -63,27 +63,27 @@
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_file_fied">File fied</label>
 
-  <div class=" col-sm-10 col-lg-10">
+  <div class="col-sm-10 col-lg-10">
     <input id="id_file_fied" name="file_fied" type="file" />
   </div>
 </div>
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_password_field">Password field</label>
 
-  <div class=" col-sm-10 col-lg-10">
+  <div class="col-sm-10 col-lg-10">
     <input class=" form-control" id="id_password_field" name="password_field" type="password" />
   </div>
 </div>
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_textarea">Textarea</label>
 
-  <div class=" col-sm-10 col-lg-10">
+  <div class="col-sm-10 col-lg-10">
     <textarea class=" form-control" cols="40" id="id_textarea" name="textarea" rows="10">
 </textarea>
   </div>
 </div>
   <div class="form-group">
-    <div class=" col-sm-offset-2 col-sm-10 col-lg-offset-2 col-lg-10">
+    <div class="col-sm-10 col-sm-offset-2 col-lg-10 col-lg-offset-2">
     <div class="checkbox">
         <label class="required">
           <input id="id_boolean_field" name="boolean_field" type="checkbox" /> <span>Boolean field</span>

--- a/testing/fixtures/partial.html
+++ b/testing/fixtures/partial.html
@@ -2,7 +2,7 @@
 <div class="form-group">
         <label class="control-label  required" for="id_char_field">Char field</label>
 
-  <div class=" ">
+  <div class="">
     <input class=" form-control" id="id_char_field" name="char_field" type="text" />
   </div>
 </div>
@@ -10,7 +10,7 @@
 <div class="form-group">
         <label class="control-label  required" for="id_choice_field">Choice field</label>
 
-  <div class=" ">
+  <div class="">
     <select class=" form-control" id="id_choice_field" name="choice_field">
 <option value="0">Zero</option>
 <option value="1">One</option>

--- a/testing/fixtures_10/basic.html
+++ b/testing/fixtures_10/basic.html
@@ -1,0 +1,93 @@
+  <div class="form-group">
+        <label class="control-label  required" for="id_char_field">Char field</label>
+
+  <div class="">
+    <input class=" form-control" id="id_char_field" name="char_field" type="text" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_choice_field">Choice field</label>
+
+  <div class="">
+    <select class=" form-control" id="id_choice_field" name="choice_field" required>
+<option value="0">Zero</option>
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required">Radio choice</label>
+  <div class="">
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_0" name="radio_choice" type="radio" value="0" required />
+          Zero
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_1" name="radio_choice" type="radio" value="1" required />
+          One
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_2" name="radio_choice" type="radio" value="2" required />
+          Two
+        </label>
+      </div>
+
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_multiple_choice">Multiple choice</label>
+
+  <div class="">
+    <select multiple="multiple" class=" form-control" id="id_multiple_choice" name="multiple_choice" required>
+<option value="0">Zero</option>
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_multiple_checkbox">Multiple checkbox</label>
+
+  <div class=" multiple-checkbox">
+    <ul id="id_multiple_checkbox"><li><label for="id_multiple_checkbox_0"><input id="id_multiple_checkbox_0" name="multiple_checkbox" type="checkbox" value="0" /> Zero</label></li>
+<li><label for="id_multiple_checkbox_1"><input id="id_multiple_checkbox_1" name="multiple_checkbox" type="checkbox" value="1" /> One</label></li>
+<li><label for="id_multiple_checkbox_2"><input id="id_multiple_checkbox_2" name="multiple_checkbox" type="checkbox" value="2" /> Two</label></li></ul>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_file_fied">File fied</label>
+
+  <div class="">
+    <input id="id_file_fied" name="file_fied" type="file" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_password_field">Password field</label>
+
+  <div class="">
+    <input class=" form-control" id="id_password_field" name="password_field" type="password" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_textarea">Textarea</label>
+
+  <div class="">
+    <textarea class=" form-control" cols="40" id="id_textarea" name="textarea" rows="10" required>
+</textarea>
+  </div>
+</div>
+  <div class="form-group">
+    <div class="">
+    <div class="checkbox">
+        <label class="required">
+          <input id="id_boolean_field" name="boolean_field" type="checkbox" required /> <span>Boolean field</span>
+        </label>
+    </div>
+  </div>
+</div>

--- a/testing/fixtures_10/horizontal.html
+++ b/testing/fixtures_10/horizontal.html
@@ -1,0 +1,93 @@
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_char_field">Char field</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <input class=" form-control" id="id_char_field" name="char_field" type="text" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_choice_field">Choice field</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <select class=" form-control" id="id_choice_field" name="choice_field" required>
+<option value="0">Zero</option>
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required">Radio choice</label>
+  <div class="col-sm-10 col-lg-10">
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_0" name="radio_choice" type="radio" value="0" required />
+          Zero
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_1" name="radio_choice" type="radio" value="1" required />
+          One
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_2" name="radio_choice" type="radio" value="2" required />
+          Two
+        </label>
+      </div>
+
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_multiple_choice">Multiple choice</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <select multiple="multiple" class=" form-control" id="id_multiple_choice" name="multiple_choice" required>
+<option value="0">Zero</option>
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_multiple_checkbox">Multiple checkbox</label>
+
+  <div class="col-sm-10 col-lg-10 multiple-checkbox">
+    <ul id="id_multiple_checkbox"><li><label for="id_multiple_checkbox_0"><input id="id_multiple_checkbox_0" name="multiple_checkbox" type="checkbox" value="0" /> Zero</label></li>
+<li><label for="id_multiple_checkbox_1"><input id="id_multiple_checkbox_1" name="multiple_checkbox" type="checkbox" value="1" /> One</label></li>
+<li><label for="id_multiple_checkbox_2"><input id="id_multiple_checkbox_2" name="multiple_checkbox" type="checkbox" value="2" /> Two</label></li></ul>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_file_fied">File fied</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <input id="id_file_fied" name="file_fied" type="file" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_password_field">Password field</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <input class=" form-control" id="id_password_field" name="password_field" type="password" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_textarea">Textarea</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <textarea class=" form-control" cols="40" id="id_textarea" name="textarea" rows="10" required>
+</textarea>
+  </div>
+</div>
+  <div class="form-group">
+    <div class="col-sm-10 col-sm-offset-2 col-lg-10 col-lg-offset-2">
+    <div class="checkbox">
+        <label class="required">
+          <input id="id_boolean_field" name="boolean_field" type="checkbox" required /> <span>Boolean field</span>
+        </label>
+    </div>
+  </div>
+</div>

--- a/testing/fixtures_10/partial.html
+++ b/testing/fixtures_10/partial.html
@@ -1,0 +1,20 @@
+
+<div class="form-group">
+        <label class="control-label  required" for="id_char_field">Char field</label>
+
+  <div class="">
+    <input class=" form-control" id="id_char_field" name="char_field" type="text" required />
+  </div>
+</div>
+
+<div class="form-group">
+        <label class="control-label  required" for="id_choice_field">Choice field</label>
+
+  <div class="">
+    <select class=" form-control" id="id_choice_field" name="choice_field" required>
+<option value="0">Zero</option>
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+  </div>
+</div>

--- a/testing/fixtures_11/basic.html
+++ b/testing/fixtures_11/basic.html
@@ -1,0 +1,93 @@
+  <div class="form-group">
+        <label class="control-label  required" for="id_char_field">Char field</label>
+
+  <div class="">
+    <input class=" form-control" id="id_char_field" name="char_field" type="text" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_choice_field">Choice field</label>
+
+  <div class="">
+    <select class=" form-control" id="id_choice_field" name="choice_field">
+<option value="0">Zero</option>
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required">Radio choice</label>
+  <div class="">
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_0" name="radio_choice" type="radio" value="0" required />
+          Zero
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_1" name="radio_choice" type="radio" value="1" required />
+          One
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_2" name="radio_choice" type="radio" value="2" required />
+          Two
+        </label>
+      </div>
+
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_multiple_choice">Multiple choice</label>
+
+  <div class="">
+    <select multiple="multiple" class=" form-control" id="id_multiple_choice" name="multiple_choice" required>
+<option value="0">Zero</option>
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_multiple_checkbox">Multiple checkbox</label>
+
+  <div class=" multiple-checkbox">
+    <ul id="id_multiple_checkbox"><li><label for="id_multiple_checkbox_0"><input id="id_multiple_checkbox_0" name="multiple_checkbox" type="checkbox" value="0" /> Zero</label></li>
+<li><label for="id_multiple_checkbox_1"><input id="id_multiple_checkbox_1" name="multiple_checkbox" type="checkbox" value="1" /> One</label></li>
+<li><label for="id_multiple_checkbox_2"><input id="id_multiple_checkbox_2" name="multiple_checkbox" type="checkbox" value="2" /> Two</label></li></ul>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_file_fied">File fied</label>
+
+  <div class="">
+    <input id="id_file_fied" name="file_fied" type="file" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_password_field">Password field</label>
+
+  <div class="">
+    <input class=" form-control" id="id_password_field" name="password_field" type="password" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label  required" for="id_textarea">Textarea</label>
+
+  <div class="">
+    <textarea class=" form-control" cols="40" id="id_textarea" name="textarea" rows="10" required>
+</textarea>
+  </div>
+</div>
+  <div class="form-group">
+    <div class="">
+    <div class="checkbox">
+        <label class="required">
+          <input id="id_boolean_field" name="boolean_field" type="checkbox" required /> <span>Boolean field</span>
+        </label>
+    </div>
+  </div>
+</div>

--- a/testing/fixtures_11/horizontal.html
+++ b/testing/fixtures_11/horizontal.html
@@ -1,0 +1,93 @@
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_char_field">Char field</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <input class=" form-control" id="id_char_field" name="char_field" type="text" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_choice_field">Choice field</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <select class=" form-control" id="id_choice_field" name="choice_field">
+<option value="0">Zero</option>
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required">Radio choice</label>
+  <div class="col-sm-10 col-lg-10">
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_0" name="radio_choice" type="radio" value="0" required />
+          Zero
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_1" name="radio_choice" type="radio" value="1" required />
+          One
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input id="id_radio_choice_2" name="radio_choice" type="radio" value="2" required />
+          Two
+        </label>
+      </div>
+
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_multiple_choice">Multiple choice</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <select multiple="multiple" class=" form-control" id="id_multiple_choice" name="multiple_choice" required>
+<option value="0">Zero</option>
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_multiple_checkbox">Multiple checkbox</label>
+
+  <div class="col-sm-10 col-lg-10 multiple-checkbox">
+    <ul id="id_multiple_checkbox"><li><label for="id_multiple_checkbox_0"><input id="id_multiple_checkbox_0" name="multiple_checkbox" type="checkbox" value="0" /> Zero</label></li>
+<li><label for="id_multiple_checkbox_1"><input id="id_multiple_checkbox_1" name="multiple_checkbox" type="checkbox" value="1" /> One</label></li>
+<li><label for="id_multiple_checkbox_2"><input id="id_multiple_checkbox_2" name="multiple_checkbox" type="checkbox" value="2" /> Two</label></li></ul>
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_file_fied">File fied</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <input id="id_file_fied" name="file_fied" type="file" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_password_field">Password field</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <input class=" form-control" id="id_password_field" name="password_field" type="password" required />
+  </div>
+</div>
+  <div class="form-group">
+        <label class="control-label col-sm-2 col-lg-2 required" for="id_textarea">Textarea</label>
+
+  <div class="col-sm-10 col-lg-10">
+    <textarea class=" form-control" cols="40" id="id_textarea" name="textarea" rows="10" required>
+</textarea>
+  </div>
+</div>
+  <div class="form-group">
+    <div class="col-sm-10 col-sm-offset-2 col-lg-10 col-lg-offset-2">
+    <div class="checkbox">
+        <label class="required">
+          <input id="id_boolean_field" name="boolean_field" type="checkbox" required /> <span>Boolean field</span>
+        </label>
+    </div>
+  </div>
+</div>

--- a/testing/fixtures_11/partial.html
+++ b/testing/fixtures_11/partial.html
@@ -1,0 +1,20 @@
+
+<div class="form-group">
+        <label class="control-label  required" for="id_char_field">Char field</label>
+
+  <div class="">
+    <input class=" form-control" id="id_char_field" name="char_field" type="text" required />
+  </div>
+</div>
+
+<div class="form-group">
+        <label class="control-label  required" for="id_choice_field">Choice field</label>
+
+  <div class="">
+    <select class=" form-control" id="id_choice_field" name="choice_field">
+<option value="0">Zero</option>
+<option value="1">One</option>
+<option value="2">Two</option>
+</select>
+  </div>
+</div>

--- a/testing/settings.py
+++ b/testing/settings.py
@@ -10,8 +10,6 @@ INSTALLED_APPS = (
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
-    'django.contrib.messages',
-    'django.contrib.staticfiles',
     'django_jinja',
     'bootstrapform_jinja',
 )
@@ -34,17 +32,15 @@ DATABASES = {
     }
 }
 
-TEMPLATE_DIRS = (
-    os.path.join(BASE_DIR, 'templates'),
-)
-
 import django
-if django.get_version().startswith('1.8'):
+if django.VERSION >= (1, 8):
     TEMPLATES = [
         {
             'BACKEND': 'django_jinja.backend.Jinja2',
             'APP_DIRS': True,
-            'DIRS': TEMPLATE_DIRS,
+            'DIRS': (
+                os.path.join(BASE_DIR, 'templates'),
+            ),
             'OPTIONS': {
                 'match_extension': '.jinja',
                 'trim_blocks': True,
@@ -53,6 +49,9 @@ if django.get_version().startswith('1.8'):
         },
     ]
 else:
+    TEMPLATE_DIRS = (
+        os.path.join(BASE_DIR, 'templates'),
+    )
     TEMPLATE_LOADERS = (
         'django_jinja.loaders.FileSystemLoader',
         'django_jinja.loaders.AppLoader'

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -8,36 +8,34 @@ GEN_HTML = bool(os.getenv('GEN_HTML', False))
 class BootstrapJinjaTemplateTagTests(TestCase):
     maxDiff = None
 
-    def _complare_html(self, r, file_name):
+    def assertHTMLEqualToFixture(self, response, file_name):
         html_file = os.path.join(settings.BASE_DIR, 'fixtures', file_name)
+        content = response.content.decode()
         if not os.path.exists(html_file) and GEN_HTML:
             print('WARNING: file "%s" missing, generating it' % file_name)
             with open(html_file, 'w') as f:
-                f.write(r.content.encode())
+                f.write(content)
             return
         with open(html_file) as f:
-            content = f.read()
+            model_content = f.read()
 
-        self.assertHTMLEqual(content, r.content.decode())
+        self.assertHTMLEqual(content, model_content)
 
     def test_simple_form(self):
         client = Client()
-        r = client.get('/simple_bs_form/')
-        self.assertContains(r, '<div class="form-group">')
-
-        self._complare_html(r, 'basic.html')
+        response = client.get('/simple_bs_form/')
+        self.assertContains(response, '<div class="form-group">', status_code=200)
+        self.assertHTMLEqualToFixture(response, 'basic.html')
 
     def test_horizontal_form(self):
         client = Client()
-        r = client.get('/horizontal_bs_form/')
-        self.assertContains(r, '<div class="form-group">')
-
-        self._complare_html(r, 'horizontal.html')
+        response = client.get('/horizontal_bs_form/')
+        self.assertContains(response, '<div class="form-group">', status_code=200)
+        self.assertHTMLEqualToFixture(response, 'horizontal.html')
 
     def test_partial_form(self):
         client = Client()
-        r = client.get('/partial_bs_form/')
-        self.assertContains(r, '<div class="form-group">')
-
-        self._complare_html(r, 'partial.html')
+        response = client.get('/partial_bs_form/')
+        self.assertContains(response, '<div class="form-group">', status_code=200)
+        self.assertHTMLEqualToFixture(response, 'partial.html')
 

--- a/testing/testapp/tests.py
+++ b/testing/testapp/tests.py
@@ -1,15 +1,23 @@
 import os
+from django import VERSION as DJANGO_VERSION
 from django.test import TestCase, Client
 from django.conf import settings
 
 GEN_HTML = bool(os.getenv('GEN_HTML', False))
+
+if DJANGO_VERSION >= (1, 11):
+    FIXTURES_DIR = 'fixtures_11'
+elif DJANGO_VERSION >= (1, 10):
+    FIXTURES_DIR = 'fixtures_10'
+else:
+    FIXTURES_DIR = 'fixtures'
 
 
 class BootstrapJinjaTemplateTagTests(TestCase):
     maxDiff = None
 
     def assertHTMLEqualToFixture(self, response, file_name):
-        html_file = os.path.join(settings.BASE_DIR, 'fixtures', file_name)
+        html_file = os.path.join(settings.BASE_DIR, FIXTURES_DIR, file_name)
         content = response.content.decode()
         if not os.path.exists(html_file) and GEN_HTML:
             print('WARNING: file "%s" missing, generating it' % file_name)

--- a/testing/testapp/views.py
+++ b/testing/testapp/views.py
@@ -1,18 +1,18 @@
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 
 from .forms import ExampleForm
 
 
 def simple_bs_form(request):
     form = ExampleForm()
-    return render_to_response('simple_bs_form.jinja', {'form': form})
+    return render(request, 'simple_bs_form.jinja', {'form': form})
 
 
 def horizontal_bs_form(request):
     form = ExampleForm()
-    return render_to_response('horizontal_bs_form.jinja', {'form': form})
+    return render(request, 'horizontal_bs_form.jinja', {'form': form})
 
 
 def partial_bs_form(request):
     form = ExampleForm()
-    return render_to_response('partial_bs_form.jinja', {'form': form})
+    return render(request, 'partial_bs_form.jinja', {'form': form})


### PR DESCRIPTION
Iterated over the code...

Most important are the first two commits. First will allow jinja to use cached version of field_macros as the context is not exposed (there is no need to do that). Second makes the templates way more clear by using jinta test syntax instead of django like filters. In addition it doesn't pollute filter namespace with strange filters.

Last two commits rewrite render and bootstrap_horizontal.

In addition, I added some comments :smile: 