### PR TITLE
Reduce python requirement from 3.6 to 3.5.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,6 @@ setup(
     ],
     packages=find_packages(),
     package_data={'bootstrapform_jinja': template_files},
-    python_requires='>=3.6',
+    python_requires='>=3.5',
     zip_safe=True,
 )


### PR DESCRIPTION
Currently, python3 in debian releases is version 3.5 and version 3.6
is only available in testing (buster).

In addition, there should not be anything in the code that specially
requires python 3.6.

Of course, I recommend everyone to use python 3.6 as it provides performance enhancements. Though, for mission critical stuff, it might not be stable enough.