### PR TITLE
Only declare default_app_config for Django versions < 3.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ lint:
 
 .PHONY: test
 test:
-	coverage run --source=bootstrapform_jinja testing/manage.py test
+	coverage run --source=bootstrapform_jinja testing/manage.py test testapp
 
 .PHONY: codecov
 codecov:

--- a/bootstrapform_jinja/__init__.py
+++ b/bootstrapform_jinja/__init__.py
@@ -1,5 +1,9 @@
 from .meta import VERSION
+import django
 
 __version__ = str(VERSION)
-
-default_app_config = 'bootstrapform_jinja.apps.BootstrapformJinjaConfig'
+if django.VERSION >= (3, 2):
+    # The declaration is only needed for older Django versions
+    pass
+else:
+    default_app_config = 'bootstrapform_jinja.apps.BootstrapformJinjaConfig'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black>=22.6.0
+black==22.6.0
 coverage==5.3
 django>=3
 django-jinja==2.10.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-black==19.10b0
+black>=22.6.0
 coverage==5.3
 django>=3
 django-jinja==2.7.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 black>=22.6.0
 coverage==5.3
 django>=3
-django-jinja==2.7.0
+django-jinja==2.10.2
 flake8==3.8.4

--- a/testing/fixtures_11/basic.html
+++ b/testing/fixtures_11/basic.html
@@ -1,18 +1,22 @@
+
   <div class="form-group">
         <label class="control-label  required" for="id_char_field">Char field</label>
 
   <div class="">
-    <input class=" form-control" id="id_char_field" name="char_field" type="text" required />
+    <input type="text" name="char_field" class=" form-control" required id="id_char_field">
   </div>
 </div>
   <div class="form-group">
         <label class="control-label  required" for="id_choice_field">Choice field</label>
 
   <div class="">
-    <select class=" form-control" id="id_choice_field" name="choice_field">
-<option value="0">Zero</option>
-<option value="1">One</option>
-<option value="2">Two</option>
+    <select name="choice_field" class=" form-control" id="id_choice_field">
+  <option value="0">Zero</option>
+
+  <option value="1">One</option>
+
+  <option value="2">Two</option>
+
 </select>
   </div>
 </div>
@@ -21,19 +25,19 @@
   <div class="">
       <div class="radio">
         <label>
-          <input id="id_radio_choice_0" name="radio_choice" type="radio" value="0" required />
+          <input type="radio" name="radio_choice" value="0" id="id_radio_choice_0" required>
           Zero
         </label>
       </div>
       <div class="radio">
         <label>
-          <input id="id_radio_choice_1" name="radio_choice" type="radio" value="1" required />
+          <input type="radio" name="radio_choice" value="1" id="id_radio_choice_1" required>
           One
         </label>
       </div>
       <div class="radio">
         <label>
-          <input id="id_radio_choice_2" name="radio_choice" type="radio" value="2" required />
+          <input type="radio" name="radio_choice" value="2" id="id_radio_choice_2" required>
           Two
         </label>
       </div>
@@ -44,41 +48,59 @@
         <label class="control-label  required" for="id_multiple_choice">Multiple choice</label>
 
   <div class="">
-    <select multiple="multiple" class=" form-control" id="id_multiple_choice" name="multiple_choice" required>
-<option value="0">Zero</option>
-<option value="1">One</option>
-<option value="2">Two</option>
+    <select name="multiple_choice" class=" form-control" required id="id_multiple_choice" multiple>
+  <option value="0">Zero</option>
+
+  <option value="1">One</option>
+
+  <option value="2">Two</option>
+
 </select>
   </div>
 </div>
   <div class="form-group">
-        <label class="control-label  required" for="id_multiple_checkbox">Multiple checkbox</label>
+        <label class="control-label  required">Multiple checkbox</label>
+  <div class="">
+      <div class="radio">
+        <label>
+          <input type="checkbox" name="multiple_checkbox" value="0" id="id_multiple_checkbox_0">
+          Zero
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input type="checkbox" name="multiple_checkbox" value="1" id="id_multiple_checkbox_1">
+          One
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input type="checkbox" name="multiple_checkbox" value="2" id="id_multiple_checkbox_2">
+          Two
+        </label>
+      </div>
 
-  <div class=" multiple-checkbox">
-    <ul id="id_multiple_checkbox"><li><label for="id_multiple_checkbox_0"><input id="id_multiple_checkbox_0" name="multiple_checkbox" type="checkbox" value="0" /> Zero</label></li>
-<li><label for="id_multiple_checkbox_1"><input id="id_multiple_checkbox_1" name="multiple_checkbox" type="checkbox" value="1" /> One</label></li>
-<li><label for="id_multiple_checkbox_2"><input id="id_multiple_checkbox_2" name="multiple_checkbox" type="checkbox" value="2" /> Two</label></li></ul>
   </div>
 </div>
   <div class="form-group">
         <label class="control-label  required" for="id_file_fied">File fied</label>
 
   <div class="">
-    <input id="id_file_fied" name="file_fied" type="file" required />
+    <input type="file" name="file_fied" required id="id_file_fied">
   </div>
 </div>
   <div class="form-group">
         <label class="control-label  required" for="id_password_field">Password field</label>
 
   <div class="">
-    <input class=" form-control" id="id_password_field" name="password_field" type="password" required />
+    <input type="password" name="password_field" class=" form-control" required id="id_password_field">
   </div>
 </div>
   <div class="form-group">
         <label class="control-label  required" for="id_textarea">Textarea</label>
 
   <div class="">
-    <textarea class=" form-control" cols="40" id="id_textarea" name="textarea" rows="10" required>
+    <textarea name="textarea" cols="40" rows="10" class=" form-control" required id="id_textarea">
 </textarea>
   </div>
 </div>
@@ -86,7 +108,7 @@
     <div class="">
     <div class="checkbox">
         <label class="required">
-          <input id="id_boolean_field" name="boolean_field" type="checkbox" required /> <span>Boolean field</span>
+          <input type="checkbox" name="boolean_field" required id="id_boolean_field"> <span>Boolean field</span>
         </label>
     </div>
   </div>

--- a/testing/fixtures_11/horizontal.html
+++ b/testing/fixtures_11/horizontal.html
@@ -1,18 +1,22 @@
+
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_char_field">Char field</label>
 
   <div class="col-sm-10 col-lg-10">
-    <input class=" form-control" id="id_char_field" name="char_field" type="text" required />
+    <input type="text" name="char_field" class=" form-control" required id="id_char_field">
   </div>
 </div>
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_choice_field">Choice field</label>
 
   <div class="col-sm-10 col-lg-10">
-    <select class=" form-control" id="id_choice_field" name="choice_field">
-<option value="0">Zero</option>
-<option value="1">One</option>
-<option value="2">Two</option>
+    <select name="choice_field" class=" form-control" id="id_choice_field">
+  <option value="0">Zero</option>
+
+  <option value="1">One</option>
+
+  <option value="2">Two</option>
+
 </select>
   </div>
 </div>
@@ -21,19 +25,19 @@
   <div class="col-sm-10 col-lg-10">
       <div class="radio">
         <label>
-          <input id="id_radio_choice_0" name="radio_choice" type="radio" value="0" required />
+          <input type="radio" name="radio_choice" value="0" id="id_radio_choice_0" required>
           Zero
         </label>
       </div>
       <div class="radio">
         <label>
-          <input id="id_radio_choice_1" name="radio_choice" type="radio" value="1" required />
+          <input type="radio" name="radio_choice" value="1" id="id_radio_choice_1" required>
           One
         </label>
       </div>
       <div class="radio">
         <label>
-          <input id="id_radio_choice_2" name="radio_choice" type="radio" value="2" required />
+          <input type="radio" name="radio_choice" value="2" id="id_radio_choice_2" required>
           Two
         </label>
       </div>
@@ -44,41 +48,59 @@
         <label class="control-label col-sm-2 col-lg-2 required" for="id_multiple_choice">Multiple choice</label>
 
   <div class="col-sm-10 col-lg-10">
-    <select multiple="multiple" class=" form-control" id="id_multiple_choice" name="multiple_choice" required>
-<option value="0">Zero</option>
-<option value="1">One</option>
-<option value="2">Two</option>
+    <select name="multiple_choice" class=" form-control" required id="id_multiple_choice" multiple>
+  <option value="0">Zero</option>
+
+  <option value="1">One</option>
+
+  <option value="2">Two</option>
+
 </select>
   </div>
 </div>
   <div class="form-group">
-        <label class="control-label col-sm-2 col-lg-2 required" for="id_multiple_checkbox">Multiple checkbox</label>
+        <label class="control-label col-sm-2 col-lg-2 required">Multiple checkbox</label>
+  <div class="col-sm-10 col-lg-10">
+      <div class="radio">
+        <label>
+          <input type="checkbox" name="multiple_checkbox" value="0" id="id_multiple_checkbox_0">
+          Zero
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input type="checkbox" name="multiple_checkbox" value="1" id="id_multiple_checkbox_1">
+          One
+        </label>
+      </div>
+      <div class="radio">
+        <label>
+          <input type="checkbox" name="multiple_checkbox" value="2" id="id_multiple_checkbox_2">
+          Two
+        </label>
+      </div>
 
-  <div class="col-sm-10 col-lg-10 multiple-checkbox">
-    <ul id="id_multiple_checkbox"><li><label for="id_multiple_checkbox_0"><input id="id_multiple_checkbox_0" name="multiple_checkbox" type="checkbox" value="0" /> Zero</label></li>
-<li><label for="id_multiple_checkbox_1"><input id="id_multiple_checkbox_1" name="multiple_checkbox" type="checkbox" value="1" /> One</label></li>
-<li><label for="id_multiple_checkbox_2"><input id="id_multiple_checkbox_2" name="multiple_checkbox" type="checkbox" value="2" /> Two</label></li></ul>
   </div>
 </div>
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_file_fied">File fied</label>
 
   <div class="col-sm-10 col-lg-10">
-    <input id="id_file_fied" name="file_fied" type="file" required />
+    <input type="file" name="file_fied" required id="id_file_fied">
   </div>
 </div>
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_password_field">Password field</label>
 
   <div class="col-sm-10 col-lg-10">
-    <input class=" form-control" id="id_password_field" name="password_field" type="password" required />
+    <input type="password" name="password_field" class=" form-control" required id="id_password_field">
   </div>
 </div>
   <div class="form-group">
         <label class="control-label col-sm-2 col-lg-2 required" for="id_textarea">Textarea</label>
 
   <div class="col-sm-10 col-lg-10">
-    <textarea class=" form-control" cols="40" id="id_textarea" name="textarea" rows="10" required>
+    <textarea name="textarea" cols="40" rows="10" class=" form-control" required id="id_textarea">
 </textarea>
   </div>
 </div>
@@ -86,7 +108,7 @@
     <div class="col-sm-10 col-sm-offset-2 col-lg-10 col-lg-offset-2">
     <div class="checkbox">
         <label class="required">
-          <input id="id_boolean_field" name="boolean_field" type="checkbox" required /> <span>Boolean field</span>
+          <input type="checkbox" name="boolean_field" required id="id_boolean_field"> <span>Boolean field</span>
         </label>
     </div>
   </div>

--- a/testing/testapp/urls.py
+++ b/testing/testapp/urls.py
@@ -1,8 +1,8 @@
-from django.conf.urls import url
+from django.urls import re_path
 from .views import simple_bs_form, horizontal_bs_form, partial_bs_form
 
 urlpatterns = [
-    url(r'^simple_bs_form/$', simple_bs_form),
-    url(r'^horizontal_bs_form/$', horizontal_bs_form),
-    url(r'^partial_bs_form/$', partial_bs_form),
+    re_path(r'^simple_bs_form/$', simple_bs_form),
+    re_path(r'^horizontal_bs_form/$', horizontal_bs_form),
+    re_path(r'^partial_bs_form/$', partial_bs_form),
 ]


### PR DESCRIPTION
Starting from django version 3.2 `default_app_config` doesn't need to be declared since there is only a single app in apps.py

Fixes the following warning: 
` RemovedInDjango41Warning: 'bootstrapform_jinja' defines default_app_config = 'bootstrapform_jinja.apps.BootstrapFormJinjaConfig'. Django now detects this configuration automatically. You can remove default_app_config.`